### PR TITLE
feat: set an empty components object when not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Simple stdout & stderr logger component. Prints JSON when `NODE_ENV=production`
 
+## Use
+
+```typescript
+const loggerComponent = createLogComponent()
+const logger = getLogger("Test")
+logger.info("log some info")
+```
+
 ## Config
 
 ### logLevel

--- a/etc/logger.api.md
+++ b/etc/logger.api.md
@@ -16,11 +16,10 @@ export function createConsoleLogComponent(components: LoggerComponents): ILogger
 export function createJsonLogComponent(components: LoggerComponents): ILoggerComponent;
 
 // @public
-export function createLogComponent(components: LoggerComponents): ILoggerComponent;
+export function createLogComponent(components?: LoggerComponents): ILoggerComponent;
 
 // @public
 export const metricDeclarations: IMetricsComponent.MetricsRecordDefinition<"wkc_logger_logs_total">;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export { metricDeclarations }
  * and json logger for NODE_ENV=production
  * @public
  */
-export function createLogComponent(components: LoggerComponents): ILoggerComponent {
+export function createLogComponent(components: LoggerComponents = {}): ILoggerComponent {
   if (process.env.NODE_ENV == "production") {
     return createJsonLogComponent(components)
   } else {

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -1,7 +1,22 @@
 import { createGenericLogComponent } from "../src/helpers"
+import { createLogComponent } from "../src"
+import * as consolePrinter from "../src/console-printer"
 
 describe("Helpers", () => {
   describe("Log Level", () => {
+    it("should log all messages when no components are provided", () => {
+      const printConsoleSpy = jest.spyOn(consolePrinter, "printConsole")
+      const loggerComponent = createLogComponent()
+      const logger = loggerComponent.getLogger("test")
+
+      logger.log("log")
+      logger.debug("debug")
+      logger.info("info")
+      logger.warn("warn")
+      logger.error("error")
+      expect(printConsoleSpy).toHaveBeenCalledTimes(5)
+    })
+
     it("should log all messages when no config log level is provided", () => {
       const print = jest.fn()
       const loggerComponent = createGenericLogComponent({}, print)


### PR DESCRIPTION
It makes it retro-compatible with versions 1.x and integration straightforward

```typescript
const loggerComponent = createLogComponent() // No need to pass an object {}
const logger = getLogger("Test")
logger.info("log some info")
```