### PR TITLE
fix: Print other information besides trace

### DIFF
--- a/src/console-printer.ts
+++ b/src/console-printer.ts
@@ -15,9 +15,8 @@ export const printConsole: LogLineFunction = (
   // logs should go to the stderr to be properly forwarded in some environments
   const extraLine = extra ? "\t" + JSON.stringify(extra) : ""
   const trace = components.tracer?.isInsideOfTraceSpan() ? components.tracer?.getTraceString() : undefined
+  const traceString = trace ? `[${trace}] ` : ""
   return process.stderr.write(
-    trace
-      ? `[${trace}] `
-      : "" + new Date().toISOString() + " [" + kind + "] (" + loggerName + "): " + message + extraLine + "\n"
+    traceString + new Date().toISOString() + " [" + kind + "] (" + loggerName + "): " + message + extraLine + "\n"
   )
 }

--- a/test/console-printer.spec.ts
+++ b/test/console-printer.spec.ts
@@ -26,11 +26,17 @@ describe("when printing a console log", () => {
       beforeEach(() => {
         isInsideOfTraceSpanMock.mockReturnValue(true)
         getTraceStringMock.mockReturnValue("aTraceString")
+        printConsole({ tracer: tracerComponentMock }, "INFO", "test", "a test message")
       })
 
       it("should print the trace", () => {
-        printConsole({ tracer: tracerComponentMock }, "INFO", "test", "a test message")
         expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("[aTraceString]"))
+      })
+
+      it("should print other information of the logger", () => {
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("[INFO]"))
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("(test)"))
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("a test message"))
       })
     })
 


### PR DESCRIPTION
This PR fixes a bug where the trace was the only thing being printed.